### PR TITLE
fix: jack control name mismatch on Acer S40-54

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+alsa-ucm-conf (1.2.15.3-1deepin3) unstable; urgency=medium
+
+  * Fix jack control name mismatch on Acer S40-54
+
+ -- qaqland <anguoli@uniontech.com>  Thu, 04 Jun 2026 16:51:22 +0800
+
 alsa-ucm-conf (1.2.15.3-1deepin2) unstable; urgency=medium
 
   * Revert t64

--- a/debian/patches/0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch
+++ b/debian/patches/0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch
@@ -1,0 +1,12 @@
+Index: alsa-ucm-conf/ucm2/HDA/HiFi-mic.conf
+===================================================================
+--- alsa-ucm-conf.orig/ucm2/HDA/HiFi-mic.conf
++++ alsa-ucm-conf/ucm2/HDA/HiFi-mic.conf
+@@ -297,7 +297,7 @@ If.micsetup {
+ 		Define {
+ 			DeviceMicName "Mic"
+ 			DeviceMicComment "Stereo Microphone"
+-			DeviceMicJack "Mic Jack"
++			DeviceMicJack "${var:MicJackControl}"
+ 			DeviceMicPriority 200
+ 		}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@
 0003-ucm2-add-improved-Librem-5-profiles.patch
 0002-fix-radxa-dragon-q6a-config.patch
 0003-ucm2-Qualcomm-qcs6490-Add-DMI-match-for-Radxa-Dragon.patch
+0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch


### PR DESCRIPTION
On Acer S40-54, there is no "Input Source" control (normal), so the code falls through to the switch-based input path, but the hardcoded "Mic Jack" control does not exist either. The actual jack detection control is "Headset Mic Jack". Use the dynamically resolved MicJackControl variable instead.

amixer -c 0 controls on the target machine:

```
numid=12,iface=CARD,name='Front Headphone Jack'
numid=14,iface=CARD,name='HDMI/DP,pcm=3 Jack'
numid=20,iface=CARD,name='HDMI/DP,pcm=4 Jack'
numid=26,iface=CARD,name='HDMI/DP,pcm=5 Jack'
numid=11,iface=CARD,name='Headset Mic Jack'
numid=13,iface=CARD,name='Speaker Phantom Jack'
numid=10,iface=MIXER,name='Master Playback Switch'
numid=9,iface=MIXER,name='Master Playback Volume'
numid=2,iface=MIXER,name='Headphone Playback Switch'
numid=1,iface=MIXER,name='Headphone Playback Volume'
numid=7,iface=MIXER,name='Capture Switch'
numid=6,iface=MIXER,name='Capture Volume'
numid=15,iface=MIXER,name='IEC958 Playback Con Mask'
numid=21,iface=MIXER,name='IEC958 Playback Con Mask',index=1
numid=27,iface=MIXER,name='IEC958 Playback Con Mask',index=2
numid=16,iface=MIXER,name='IEC958 Playback Pro Mask'
numid=22,iface=MIXER,name='IEC958 Playback Pro Mask',index=1
numid=28,iface=MIXER,name='IEC958 Playback Pro Mask',index=2
numid=17,iface=MIXER,name='IEC958 Playback Default'
numid=23,iface=MIXER,name='IEC958 Playback Default',index=1
numid=29,iface=MIXER,name='IEC958 Playback Default',index=2
numid=18,iface=MIXER,name='IEC958 Playback Switch'
numid=24,iface=MIXER,name='IEC958 Playback Switch',index=1
numid=30,iface=MIXER,name='IEC958 Playback Switch',index=2
numid=5,iface=MIXER,name='Auto-Mute Mode'
numid=42,iface=MIXER,name='Dmic0 Capture Switch'
numid=41,iface=MIXER,name='Dmic0 Capture Volume'
numid=44,iface=MIXER,name='Dmic1 2nd Capture Volume'
numid=43,iface=MIXER,name='EQIIR10.0 eqiir_coef_10'
numid=45,iface=MIXER,name='EQIIR11.0 eqiir_coef_11'
numid=37,iface=MIXER,name='EQIIR2.0 eqiir_bytes_2'
numid=8,iface=MIXER,name='Headset Mic Boost Volume'
numid=35,iface=MIXER,name='PGA1.0 1 Master Playback Volume'
numid=36,iface=MIXER,name='PGA2.0 2 Master Capture Volume'
numid=46,iface=MIXER,name='PGA30.0 30 Playback Volume'
numid=47,iface=MIXER,name='PGA31.0 31 Playback Volume'
numid=38,iface=MIXER,name='PGA7.0 7 Master Playback Volume'
numid=39,iface=MIXER,name='PGA8.0 8 Master Playback Volume'
numid=40,iface=MIXER,name='PGA9.0 9 Master Playback Volume'
numid=4,iface=MIXER,name='Speaker Playback Switch'
numid=3,iface=MIXER,name='Speaker Playback Volume'
numid=19,iface=PCM,name='ELD',device=3
numid=32,iface=PCM,name='Playback Channel Map',device=3
numid=25,iface=PCM,name='ELD',device=4
numid=33,iface=PCM,name='Playback Channel Map',device=4
numid=31,iface=PCM,name='ELD',device=5
numid=34,iface=PCM,name='Playback Channel Map',device=5
```

PMS: 361205