### PR TITLE
fix: reformat quilt patch 0004 to standard header format

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+alsa-ucm-conf (1.2.15.3-1deepin4) unstable; urgency=medium
+
+  * Fix patch format in 0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch
+    to use standard quilt format.
+
+ -- qaqland <anguoli@uniontech.com>  Mon, 08 Jun 2026 17:51:43 +0800
+
 alsa-ucm-conf (1.2.15.3-1deepin3) unstable; urgency=medium
 
   * Fix jack control name mismatch on Acer S40-54

--- a/debian/patches/0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch
+++ b/debian/patches/0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch
@@ -1,8 +1,6 @@
-Index: alsa-ucm-conf/ucm2/HDA/HiFi-mic.conf
-===================================================================
---- alsa-ucm-conf.orig/ucm2/HDA/HiFi-mic.conf
-+++ alsa-ucm-conf/ucm2/HDA/HiFi-mic.conf
-@@ -297,7 +297,7 @@ If.micsetup {
+--- a/ucm2/HDA/HiFi-mic.conf
++++ b/ucm2/HDA/HiFi-mic.conf
+@@ -297,7 +297,7 @@
  		Define {
  			DeviceMicName "Mic"
  			DeviceMicComment "Stereo Microphone"
@@ -10,3 +8,4 @@ Index: alsa-ucm-conf/ucm2/HDA/HiFi-mic.conf
 +			DeviceMicJack "${var:MicJackControl}"
  			DeviceMicPriority 200
  		}
+ 


### PR DESCRIPTION
```
dpkg-source: warning: unexpected end of diff 'alsa-ucm-conf-1.2.15.3/debian/patches/0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch'
dpkg-source: info: applying 0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch patching file ucm2/HDA/HiFi-mic.conf
patch unexpectedly ends in middle of line
Hunk #1 FAILED at 297.
1 out of 1 hunk FAILED
dpkg-source: info: the patch has fuzz which is not allowed, or is malformed
dpkg-source: info: if patch '0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch' is correctly applied by quilt, use 'quilt refresh' to update it
dpkg-source: info: restoring quilt backup files for 0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch
dpkg-source: error: LC_ALL=C patch -t -F 0 -N -p1 -u -V never -E -b -B .pc/0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch/ --reject-file=- < alsa-ucm-conf-1.2.15.3/debian/patches/0004-ucm2-HDA-HiFi-mic-use-dynamic-MicJackControl.patch subprocess returned exit status 1
```